### PR TITLE
Fixed guerrillaAI not working with HLC weapons

### DIFF
--- a/ca/ai/fn_unitGuerrillaAI.sqf
+++ b/ca/ai/fn_unitGuerrillaAI.sqf
@@ -137,6 +137,11 @@ private _weaponMode = "";
 } forEach ([(configFile >> "CfgWeapons" >> _weapon), "modes", []] call BIS_fnc_returnConfigEntry);
 private _cycleDelay = [(configFile >> "CfgWeapons" >> _weapon >> _weaponMode), "reloadTime", 999] call BIS_fnc_returnConfigEntry;
 
+// Some addons use strings/expressions instead of numbers, so we need to do an extra step
+if (typeName _cycleDelay == typeName "") then {
+        _cycleDelay = call compile _cycleDelay;
+};
+
 // If the delay between 2 rounds is greater than this value, we don't consider the unit's weapon as being full-auto
 if (_cycleDelay < 0.5) then {
 


### PR DESCRIPTION
Turns out some mod authors use strings for certain weapon parameters (in this case `reloadTime` - the delay between 2 rounds when firing) instead of numbers. ArmA 3 itself doesn't care about this, as it just compiles the string into code and uses whatever result comes out of it as the value. I, however, wasn't aware of this, so I didn't implement a failsafe for that - until now.