### PR TITLE
Fix Zeus UI ignoring gAI/sAI buttons

### DIFF
--- a/ca/zeus/zeus_ui/fn_spawnGroupForZeus.sqf
+++ b/ca/zeus/zeus_ui/fn_spawnGroupForZeus.sqf
@@ -6,7 +6,15 @@
 //
 //		See parameters for ca_fnc_spawngroup.
 
-params ["_units", "_camPos", "_gear", "_side"];
+params [
+	"_units",
+	"_camPos",
+	"_gear",
+	"_side",
+	["_spawn_vcom", false, [false]],
+	["_spawn_guerrillas", false, [false]],
+	["_spawn_suppress", false, [false]]
+];
 
 _group = [_units, _camPos, _gear, _side] call ca_fnc_spawngroup;
 
@@ -17,17 +25,17 @@ _group = [_units, _camPos, _gear, _side] call ca_fnc_spawngroup;
 
 } forEach allCurators;
 
-if ((!isNil "zeus_spawn_vcom") and {!zeus_spawn_vcom}) then
+if (_spawn_vcom) then
 {
 	_group setVariable ["Vcm_Disable", true, true];
 };
 
-if ((!isNil "zeus_spawn_guerrillas") and {zeus_spawn_guerrillas}) then
+if (_spawn_guerrillas) then
 {
 	[_group] call ca_fnc_groupGuerrillaAI;
 };
 
-if ((!isNil "zeus_spawn_suppress") and {zeus_spawn_suppress}) then
+if (_spawn_suppress) then
 {
 	[_group] call ca_fnc_groupSuppressiveAI;
 };

--- a/ca/zeus/zeus_ui/fn_spawnVehicleGroupForZeus.sqf
+++ b/ca/zeus/zeus_ui/fn_spawnVehicleGroupForZeus.sqf
@@ -1,23 +1,36 @@
 //	Zeus extensions for CA, by Bubbus.
-//	
+//
 //	ca_fnc_spawnvehiclegroup does not add spawned units to zeus so they can't move them around etc.  We fix that here.
 //
 //	PARAMETERS:
-//	
+//
 //		See parameters for ca_fnc_spawnvehiclegroup.
 
-params ["_units", "_camPos", "_veh", "_gear", "_side"];
+params [
+	"_units",
+	"_camPos",
+	"_veh",
+	"_gear",
+	"_side",
+	["_spawn_suppress", false, [false]]
+];
 
 _groupVeh = [_units, _camPos, _veh, _gear, _side] call ca_fnc_spawnvehiclegroup;
 
 {
 	_group = _groupVeh select 0;
 	_vehicle = _groupVeh select 1;
-	
+
 	_units = units _group;
 	_units pushBack _vehicle;
 	_curator = _x;
-	
+
 	_curator addCuratorEditableObjects [_units, true];
-	
+
 } forEach allCurators;
+
+if (_spawn_suppress) then
+{
+	private _group = _groupVeh select 0;
+	[_group] call ca_fnc_groupSuppressiveAI;
+};

--- a/ca/zeus/zeus_ui/fn_zeusDoSpawn.sqf
+++ b/ca/zeus/zeus_ui/fn_zeusDoSpawn.sqf
@@ -1,10 +1,10 @@
 //	Zeus extensions for CA, by Bubbus.
-//	
+//
 //	Spawns a squad where the zeus camera is aiming, according to the passed-in squad definition.
 //	NOTE: This is not a squad definition from ca_fnc_zeusSetupUnits - it has been transformed by ca_fnc_zeusFillUnits before it reaches here.
 //
 //	PARAMETERS:
-//	
+//
 //		_def
 //			The squad definition to use for spawning the squad.
 
@@ -16,6 +16,11 @@ if (isNil "_def") exitWith {};
 
 _type = _def select 0;
 
+// DUCT TAPE, LOTS OF DUCT TAPE
+if (isNil "zeus_spawn_vcom") then {zeus_spawn_vcom = false};
+if (isNil "zeus_spawn_guerrillas") then {zeus_spawn_guerrillas = false};
+if (isNil "zeus_spawn_suppress") then {zeus_spawn_suppress = false};
+
 switch (_type) do
 {
 
@@ -24,18 +29,18 @@ switch (_type) do
 		_units = _def select 1;
 		_gear = _def select 2;
 		_side = _def select 3;
-		
-		[_units, _camPos, _gear, _side] remoteExec ["ca_fnc_spawnGroupForZeus", 2];
+
+		[_units, _camPos, _gear, _side, zeus_spawn_vcom, zeus_spawn_guerrillas, zeus_spawn_suppress] remoteExec ["ca_fnc_spawnGroupForZeus", 2];
 	};
-	
+
 	case "veh":
 	{
 		_units = _def select 1;
 		_veh = _def select 2;
 		_gear = _def select 3;
 		_side = _def select 4;
-		
-		[_units, _camPos, _veh, _gear, _side] remoteExec ["ca_fnc_spawnVehicleGroupForZeus", 2];
+
+		[_units, _camPos, _veh, _gear, _side, zeus_spawn_suppress] remoteExec ["ca_fnc_spawnVehicleGroupForZeus", 2];
 	};
 
 };


### PR DESCRIPTION
**When merged this pull request will:**

- fix @Bubbus's Zeus UI ignoring the state of the gAI/sAI buttons.

Previously, the UI used global vars to remember the state of these buttons. When spawning units (or vehicles), the menu would offload the spawn functions onto the server, but wouldn't send the state of the variables along in the remoteExec calls. BEcause of this, the server would fall back to its own set of global variables, which never got modified, meaning the sAI/gAI features were always disabled (by default).

I brought this issue up to Bubbus and he seemed fine with me working out this fix for him. I originally wrote it prior to one of Wallace's missions, so while it was slightly rushed, we tested it shortly after and confirmed that it's working. Nonetheless I hope to improve this menu in the future to enable Zeus players to set the parameters for gAI/sAI (instead of always using the default values).