### PR TITLE
Improved ZeusUI error handling

### DIFF
--- a/ca/zeus_ui/config/ca_units.hpp
+++ b/ca/zeus_ui/config/ca_units.hpp
@@ -143,4 +143,71 @@ class CA_ZeusUI_Units
 			units[] = {"vc", "vd", "vg"};
 		};
 	};
+
+	class AAF_Infantry
+	{
+		categoryName = "AAF Infantry";
+		gear = "ind_f";
+		side = "resistance";
+
+		// Units definition
+		class Rifleman
+		{
+			unitName = "AAF Rifleman";
+			units[] = {"r"};
+		};
+
+		class Fireteam_6x
+		{
+			unitName = "AAF Fireteam 6x";
+			units[] = {"ftl", "ar", "aar", "rat", "r", "r"};
+		};
+
+		class MAT_Team
+		{
+			unitName = "AAF MAT Team";
+			units[] = {"matag", "matg"};
+		};
+
+		class MMG_Team
+		{
+			unitName = "AAF MMG Team";
+			units[] = {"mmgag", "mmgg"};
+		};
+	};
+
+	class AAF_Vehicles
+	{
+		categoryName = "AAF Vehicles";
+		gear = "ind_f";
+		side = "resistance";
+
+		class MBT52_Kuma		// Classnames can't contain '-'
+		{
+			unitName = "MBT-52 Kuma";
+			vehicle = "I_MBT_03_cannon_F";
+			units[] = {"vc", "vd", "vg"};
+		};
+
+		class AFV4_Gorgon
+		{
+			unitName = "AFV-4 Gorgon";
+			vehicle = "I_APC_Wheeled_03_cannon_F";
+			units[] = {"vc", "vd", "vg"};
+		};
+
+		class FV720_Mora
+		{
+			unitName = "FV-720 Mora";
+			vehicle = "I_APC_tracked_03_cannon_F";
+			units[] = {"vc", "vd", "vg"};
+		};
+
+		class Strider_HMG
+		{
+			unitName = "Strider HMG";
+			vehicle = "I_MRAP_03_hmg_F";
+			units[] = {"vc", "vd", "vg"};
+		};
+	};
 };

--- a/ca/zeus_ui/fn_compileLists.sqf
+++ b/ca/zeus_ui/fn_compileLists.sqf
@@ -42,6 +42,7 @@ private _allCategoriesVars = [];
 		case "east": {_categorySide = east};
 		case "resistance": {_categorySide = resistance};
 		case "civilian": {_categorySide = civilian};
+		default {_categorySide = sideUnknown};		// Fallback for incorrect side inputs
 	};
 
 	// Iterate through the unit classes inside this category


### PR DESCRIPTION
- Added a fallback value to the side value of categories, so that incorrect syntax leads to the units not being spawned (rather than throwing an SQF error)
- Also added a notification message (via chat, hint and RPT log) when trying to spawn units from a category without a valid side, telling the mission maker to check up on their ca_units.hpp file
- Added some default categories for AAF