### PR TITLE
Updated ca_onDeath due to ACE medical rewrite

### DIFF
--- a/ca/respawn/ca_onDeath.sqf
+++ b/ca/respawn/ca_onDeath.sqf
@@ -76,7 +76,7 @@ _loadout = (_unit getVariable "f_var_assignGear");
 _unit setVariable ["f_var_assignGear_done",false,true];
 [_loadout,player] call f_fnc_assignGear;
 [] execVM "f\radios\radio_init.sqf";
-[player,player] call ACE_medical_fnc_treatmentAdvanced_fullHealLocal;
+[player] call ace_medical_treatment_fnc_fullHealLocal;      // medical rewrite compatibility (ACE v3.13.0 and higher)
 
 // Exit spectator and setpos to respawn_west
 // ====================================================================================================================


### PR DESCRIPTION
`ACE_medical_fnc_treatmentAdvanced_fullHealLocal` has been renamed to `ace_medical_treatment_fnc_fullHealLocal` as a consequence of the ACE3 medical rewrite. In its current state, this function will throw an error - the proposed change fixes that.