### PR TITLE
Updated Gearscript for reopening setup.

### DIFF
--- a/f/assignGear/f_assignGear_aaf.sqf
+++ b/f/assignGear/f_assignGear_aaf.sqf
@@ -9,6 +9,7 @@
 //		co			- commander
 //		dc 			- deputy commander / squad leader
 //		m 			- medic
+//		surgeon		- surgeon (advanced medical -- PAK, surgical kit)
 //		ftl			- fire team leader
 //		ar 			- automatic rifleman
 //		aar			- assistant automatic rifleman

--- a/f/assignGear/f_assignGear_aaf.sqf
+++ b/f/assignGear/f_assignGear_aaf.sqf
@@ -417,7 +417,24 @@ switch (_typeofUnit) do
 		_unit addWeapon "Binocular";		
 		_unit linkItem "ItemGPS";
 		_unit addItem "ACE_microDAGR";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
 		["m"] call _backpack;
+	};
+	
+// LOADOUT: SURGEON
+	case "surgeon":
+	{
+		_unit addweapon _carbine;
+		_unit addmagazines [_carbinemag,5];
+		_unit addmagazines [_carbinemag_tr,2];		
+		_unit addmagazines [_smokegrenade,4];
+		{_unit addItem _firstaid} forEach [1,2,3,4];
+		{_unit addItem "ACE_splint"} forEach [1,2,3,4,5,6,7,8,9,10];	
+		_unit addWeapon "Binocular";		
+		_unit linkItem "ItemGPS";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
+		_unit addItem "ACE_microDAGR";
+		["surgeon"] call _backpack;
 	};
 
 // LOADOUT: FIRE TEAM LEADER

--- a/f/assignGear/f_assignGear_aaf_b.sqf
+++ b/f/assignGear/f_assignGear_aaf_b.sqf
@@ -9,28 +9,74 @@ case "m":
 	if (_loadout <= 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
-		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 8];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 4];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 4];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
 	};
 
 	// LOADOUT: HEAVY
 	if (_loadout == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
-		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 30];
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 8];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 8];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+	};
+};
+
+// BACKPACK: SURGEON
+case "surgeon":
+{
+	// LOADOUT: MEDIUM
+	if (_loadout <= 1) then {
+		_unit addBackpack _bagmedium;
+		clearMagazineCargoGlobal (unitBackpack _unit);
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 8];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 4];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 4];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_personalAidKit", 1];	
+	};
+
+	// LOADOUT: HEAVY
+	if (_loadout == 2) then {
+		_unit addBackpack _bagmedium;
+		clearMagazineCargoGlobal (unitBackpack _unit);
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 8];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 8];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_personalAidKit", 1];	
 	};
 };
 

--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -9,6 +9,7 @@
 //		co			- commander
 //		dc 			- deputy commander / squad leader
 //		m 			- medic
+//		surgeon		- surgeon (advanced medical -- PAK, surgical kit)
 //		ftl			- fire team leader
 //		ar 			- automatic rifleman
 //		aar			- assistant automatic rifleman

--- a/f/assignGear/f_assignGear_csat.sqf
+++ b/f/assignGear/f_assignGear_csat.sqf
@@ -427,7 +427,24 @@ switch (_typeofUnit) do
 		_unit addWeapon "Binocular";		
 		_unit linkItem "ItemGPS";
 		_unit addItem "ACE_microDAGR";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
 		["m"] call _backpack;
+	};
+	
+// LOADOUT: SURGEON
+	case "surgeon":
+	{
+		_unit addweapon _carbine;
+		_unit addmagazines [_carbinemag,5];
+		_unit addmagazines [_carbinemag_tr,2];		
+		_unit addmagazines [_smokegrenade,4];
+		{_unit addItem _firstaid} forEach [1,2,3,4];
+		{_unit addItem "ACE_splint"} forEach [1,2,3,4,5,6,7,8,9,10];	
+		_unit addWeapon "Binocular";		
+		_unit linkItem "ItemGPS";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
+		_unit addItem "ACE_microDAGR";
+		["surgeon"] call _backpack;
 	};
 
 // LOADOUT: FIRE TEAM LEADER

--- a/f/assignGear/f_assignGear_csat_b.sqf
+++ b/f/assignGear/f_assignGear_csat_b.sqf
@@ -9,28 +9,74 @@ case "m":
 	if (_loadout <= 1) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
-		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 8];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 4];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 4];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
 	};
 
 	// LOADOUT: HEAVY
 	if (_loadout == 2) then {
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
-		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 30];
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 8];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 8];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+	};
+};
+
+// BACKPACK: SURGEON
+case "surgeon":
+{
+	// LOADOUT: MEDIUM
+	if (_loadout <= 1) then {
+		_unit addBackpack _bagmedium;
+		clearMagazineCargoGlobal (unitBackpack _unit);
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 8];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 4];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 4];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_personalAidKit", 1];	
+	};
+
+	// LOADOUT: HEAVY
+	if (_loadout == 2) then {
+		_unit addBackpack _bagmedium;
+		clearMagazineCargoGlobal (unitBackpack _unit);
+//		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_bloodIV", 10];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_tourniquet", 8];
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_splint", 8];	
+		(unitBackpack _unit) addItemCargoGlobal ["FSGm_ItemMedicBagMil", 1];	
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_personalAidKit", 1];	
 	};
 };
 

--- a/f/assignGear/f_assignGear_nato.sqf
+++ b/f/assignGear/f_assignGear_nato.sqf
@@ -421,7 +421,7 @@ switch (_typeofUnit) do
 		_unit addWeapon "Binocular";		
 		_unit linkItem "ItemGPS";
 		_unit addItem "ACE_microDAGR";
-		_unit addItem "ACE_surgicalKit";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
 		["m"] call _backpack;
 	};
 // LOADOUT: SURGEON
@@ -435,7 +435,7 @@ switch (_typeofUnit) do
 		{_unit addItem "ACE_splint"} forEach [1,2,3,4,5,6,7,8,9,10];	
 		_unit addWeapon "Binocular";		
 		_unit linkItem "ItemGPS";
-		_unit addItem "ACE_surgicalKit";
+		// _unit addItem "ACE_surgicalKit"; //uncomment for reopening wounds
 		_unit addItem "ACE_microDAGR";
 		["surgeon"] call _backpack;
 	};

--- a/f/assignGear/f_assignGear_nato_b.sqf
+++ b/f/assignGear/f_assignGear_nato_b.sqf
@@ -10,8 +10,9 @@ case "m":
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 //		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
@@ -26,8 +27,9 @@ case "m":
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 //		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		
@@ -45,7 +47,9 @@ case "surgeon":
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 //		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 4];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 15]; //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 10];       //uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 25];    //comment this out for reopening wounds setup
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 10];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 5];		
@@ -61,7 +65,9 @@ case "surgeon":
 		_unit addBackpack _bagmedium;
 		clearMagazineCargoGlobal (unitBackpack _unit);
 //		(unitBackpack _unit) addMagazineCargoGlobal [_smokegrenade, 6];
-		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 30];
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 20];  //uncomment these two for reopening wounds setup
+		// (unitBackpack _unit) addItemCargoGlobal ["ACE_quikclot", 15]; 	//uncomment these two for reopening wounds setup
+		(unitBackpack _unit) addItemCargoGlobal ["ACE_elasticBandage", 35];	//comment this out for reopening wounds setup	
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_morphine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_epinephrine", 15];
 		(unitBackpack _unit) addItemCargoGlobal ["ACE_adenosine", 8];		

--- a/f/briefing/f_briefing_east.sqf
+++ b/f/briefing/f_briefing_east.sqf
@@ -32,6 +32,8 @@ ENEMY FORCES
 FRIENDLY FORCES
 <br/>
 *** Insert information about friendly forces here.***
+<br/>
+*** Missionmaker = smooth of brain if briefing unfilled***
 "]];
 
 // ====================================================================================

--- a/f/briefing/f_briefing_resistance.sqf
+++ b/f/briefing/f_briefing_resistance.sqf
@@ -31,6 +31,8 @@ ENEMY FORCES
 FRIENDLY FORCES
 <br/>
 *** Insert information about friendly forces here.***
+<br/>
+*** Missionmaker = smooth of brain if briefing unfilled.***
 "]];
 
 // ====================================================================================

--- a/f/briefing/f_briefing_west.sqf
+++ b/f/briefing/f_briefing_west.sqf
@@ -32,6 +32,8 @@ ENEMY FORCES
 FRIENDLY FORCES
 <br/>
 *** Insert information about friendly forces here.***
+<br/>
+*** Missionmaker = smooth of brain if briefing unfilled.***
 "]];
 
 // ====================================================================================


### PR DESCRIPTION
NATO, AAF, and CSAT medical gear loadouts have been edited to include a default of elastic bandages, and optional 'comment in' SurgicalKit and reopening bandages setup featuring quickclots.

AAF and CSAT did not have surgeon role despite being called on the unit, updated to ensure factions have this setup.

Added a spicy quip to roast missionmakers if they didn't fill out the briefing.